### PR TITLE
chore(cmx): Actually add --network

### DIFF
--- a/replicated/cmx_vm.go
+++ b/replicated/cmx_vm.go
@@ -150,6 +150,10 @@ func (m *Replicated) VmCreate(
 		cmd = append(cmd, "--instance-type", instanceType)
 	}
 
+	if network != "" {
+		cmd = append(cmd, "--network", network)
+	}
+
 	containerWithCmd := replicated.With(cacheBustingExec(cmd))
 
 	stdout, err := containerWithCmd.Stdout(ctx)


### PR DESCRIPTION
The `--network` flag got missed, this adds it.