### PR TITLE
fix(replicated): network update policy command

### DIFF
--- a/replicated/cmx_network.go
+++ b/replicated/cmx_network.go
@@ -163,7 +163,6 @@ func (m *Replicated) NetworkUpdatePolicy(
 		"/replicated",
 		"network",
 		"update",
-		"policy",
 	}
 
 	if networkID != "" {


### PR DESCRIPTION
Command has extra "policy"

```
84  : ┆ Replicated.networkUpdatePolicy(networkId: "483d7f4394e97c60c9a46e6b62e9d3de16a8892f548d64a2334656e73236e12b", policy: "airgap"): String!
85  : ┆ ┆ withEnvVariable DAGGER_CACHEBUSTER_CBE=2025-12-04 06:45:42.707819168 +0000 UTC m=+0.015092170
85  : ┆ ┆ Container.withEnvVariable DONE [0.0s]
86  : ┆ ┆ withExec /replicated network update policy 483d7f4394e97c60c9a46e6b62e9d3de16a8892f548d64a2334656e73236e12b --policy airgap --output json
87  : ┆ ┆ Container.stdout: String!
86  : ┆ ┆ withExec /replicated network update policy 483d7f4394e97c60c9a46e6b62e9d3de16a8892f548d64a2334656e73236e12b --policy airgap --output json
86  : ┆ ┆ [0.3s] | Error: must provide network id or name: Network with name or ID 'policy' not found
```